### PR TITLE
Popup version bump

### DIFF
--- a/popup-switcher.el
+++ b/popup-switcher.el
@@ -5,8 +5,8 @@
 ;; Author: Kostafey <kostafey@gmail.com>
 ;; URL: https://github.com/kostafey/popup-switcher
 ;; Keywords: popup, switch, buffers, functions
-;; Version: 0.2.10
-;; Package-Requires: ((cl-lib "0.3")(popup "0.5.2"))
+;; Version: 0.2.11
+;; Package-Requires: ((cl-lib "0.3")(popup "0.5.3"))
 
 ;; This file is not part of GNU Emacs.
 
@@ -115,7 +115,7 @@ WINDOW-CENTER - if t, overrides `psw-in-window-center' var value."
                                                 :scroll-bar t
                                                 :margin-left 1
                                                 :margin-right 1
-                                                :around nil
+                                                :around t
                                                 :isearch t
                                                 :fallback fallback)))
             target-item-name))


### PR DESCRIPTION
Hi. As promissid, I'd like to merge `popup-imenu` into `popup-switcher` and start using it as default imenu selector. But I ran into an issue running `popup-switcher` backed by latest `popup` release version 0.5.3, which is default in my setup. Issue is that the first menu item shifts to the right by 1 place. I've made an issue reproduction branch here https://github.com/ancane/popup-switcher/tree/popup-shift. Looks like it's caused by `around nil` param.
Also popup version 0.5.3 features `isearch-filter` function for popup items filtering.
Thanks.