### PR TITLE
Fix for issue #19 require dash library and projectile lazily

### DIFF
--- a/popup-switcher.el
+++ b/popup-switcher.el
@@ -29,6 +29,7 @@
 (require 'artist)
 (require 'recentf)
 (require 'dash)                         ; use -mapcat inside psw-flatten-index
+(require 'imenu)
 
 (defgroup popup-switcher nil
   "Switch to other buffers and files via popup."
@@ -111,14 +112,15 @@ Highlight current buffer for `psw-switch-buffer' when nil (by default)."
                              (1- buffer-name-length)
                              buffer-name-length))))))
 
+(defun psw-get-buffer-list (file-buffers-only)
   (cl-remove-if (lambda (buf) (or (minibufferp buf)
-                             (let ((buf-name (buffer-name buf)))
-                               (and (>= (length buf-name) 2)
-                                    (equal (substring buf-name 0 2) " *")))
-                             (if file-buffers-only
-                                 (or (not (with-current-buffer buf
-                                            (buffer-file-name)))
-                                     (psw-is-temp-buffer buf)))))
+                                  (let ((buf-name (buffer-name buf)))
+                                    (and (>= (length buf-name) 2)
+                                         (equal (substring buf-name 0 2) " *")))
+                                  (if file-buffers-only
+                                      (or (not (with-current-buffer buf
+                                                 (buffer-file-name)))
+                                          (psw-is-temp-buffer buf)))))
                 (buffer-list)))
 
 (defun psw-copy-face (old-face new-face)


### PR DESCRIPTION
This fixes the issue #19.  

Overview:
* Add ``(require 'dash)`` as it is required: the code uses its ``-mapcat`` function.
* The functions that use projectile now lazily require projectile and checks for required functions and variables to be bound.  When these conditions are not met, the function issues a *user-error* instructing user to install projectile.
* The ``psw-switch-buffer`` function has 1 argument but can be used without.  The argument is now declared optional.
* Identified the dash version 2.10.0 as a dependency: it's the version where the latest version of -mapcar was written.
* Also updated the version of popup-switcher to 0.2.15.